### PR TITLE
Add support to use the existing teardown logic in common.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: kubectl
       run: curl -LO https://dl.k8s.io/release/v1.25.4/bin/linux/amd64/kubectl
     - name: start from local
-      run: ./main.sh
+      run: ./main.sh up
     - name: verify
       run: |
         dpkg -l | grep bcc

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ you need to locate your BCC lib and linux header.
 3. The scripts are the source for the kepler cluster commands like `./kind/common.sh`.
 4. [`kubectl`](https://dl.k8s.io/release/v1.25.4)
 5. run `./main.sh up` to set up your local env.
-6. run `./main.sh down` to teardown your local env.
+6. run `./main.sh down` to tear down your local env.
 
 ## Docker registry
 There's a docker registry available which is exposed at `localhost:5001`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ you need to locate your BCC lib and linux header.
 2. modify kind [config](./kind/manifests/kind.yml) to make sure `extraMounts:` cover linux header and BCC.
 3. The scripts are the source for the kepler cluster commands like `./kind/common.sh`.
 4. [`kubectl`](https://dl.k8s.io/release/v1.25.4)
-5. run `./main.sh` to set up your local env.
+5. run `./main.sh up` to set up your local env.
+6. run `./main.sh down` to teardown your local env.
 
 ## Docker registry
 There's a docker registry available which is exposed at `localhost:5001`.

--- a/kind/common.sh
+++ b/kind/common.sh
@@ -17,7 +17,8 @@
 # Copyright 2022 The Kepler Contributors
 #
 
-set -ex pipefail
+set -ex
+set -o pipefail
 
 _registry_port="5001"
 _registry_name="kind-registry"
@@ -210,9 +211,15 @@ function _kind_up() {
 }
 
 function main() {
-    _kind_up
-
-    echo "cluster '$CLUSTER_NAME' is ready"
+    case $1 in
+    up)
+        _kind_up
+        echo "cluster '$CLUSTER_NAME' is ready"
+        ;;
+    down)
+        down
+        ;;
+    esac
 }
 
 function down() {
@@ -226,4 +233,4 @@ function down() {
     rm -f ${KIND_DIR}/kind.yml
 }
 
-main
+main "$@"

--- a/kind/common.sh
+++ b/kind/common.sh
@@ -217,12 +217,16 @@ function main() {
         echo "cluster '$CLUSTER_NAME' is ready"
         ;;
     down)
-        down
+        _kind_down
+        ;;
+    *)
+        _kind_up
+        echo "cluster '$CLUSTER_NAME' is ready"
         ;;
     esac
 }
 
-function down() {
+function _kind_down() {
     _fetch_kind
     if [ -z "$($KIND get clusters | grep ${CLUSTER_NAME})" ]; then
         return
@@ -230,7 +234,9 @@ function down() {
     # Avoid failing an entire test run just because of a deletion error
     $KIND delete cluster --name=${CLUSTER_NAME} || "true"
     $CTR_CMD rm -f ${REGISTRY_NAME} >> /dev/null
-    rm -f ${KIND_DIR}/kind.yml
+    find ${KIND_DIR} -name kind.yml -maxdepth 1 -delete
+    find ${KIND_DIR} -name local-registry.yml -maxdepth 1 -delete
+    find ${KIND_DIR} -name '.*' -maxdepth 1 -delete
 }
 
 main "$@"

--- a/main.sh
+++ b/main.sh
@@ -16,4 +16,4 @@
 #
 # Copyright 2023 The Kepler Contributors
 #
-./kind/common.sh
+./kind/common.sh $1


### PR DESCRIPTION
This PR adds the use of an existing function in `kind/common.sh` which teardown the local env and cleans the user space. This makes it much more convenient to delete the cluster once local testing is completed and without any manual effort

CC: @rootfs 