### PR TITLE
Add make parameter to delete the local kind cluster

### DIFF
--- a/kind/common.sh
+++ b/kind/common.sh
@@ -17,7 +17,7 @@
 # Copyright 2022 The Kepler Contributors
 #
 
-set -ex pipefail
+set -eox pipefail
 
 _registry_port="5001"
 _registry_name="kind-registry"
@@ -210,12 +210,27 @@ function _kind_up() {
 }
 
 function main() {
-    _kind_up
-
-    echo "cluster '$CLUSTER_NAME' is ready"
+    if [ "$#" -lt "1" ]
+    then
+        echo "invalid parameter list for $0"
+    elif [ "$#" -eq "0" ]
+    then
+        _kind_up
+        echo "cluster '$CLUSTER_NAME' is ready"
+    elif [ "$1" == "up" ]
+    then
+        _kind_up
+        echo "cluster '$CLUSTER_NAME' is ready"
+    elif [ "$1" == "down" ]
+    then
+        _kind_down
+        echo "cluster '$CLUSTER_NAME' has been deleted"
+    else
+        echo "invalid parameter"
+    fi
 }
 
-function down() {
+function _kind_down() {
     _fetch_kind
     if [ -z "$($KIND get clusters | grep ${CLUSTER_NAME})" ]; then
         return
@@ -226,4 +241,4 @@ function down() {
     rm -f ${KIND_DIR}/kind.yml
 }
 
-main
+main $@

--- a/main.sh
+++ b/main.sh
@@ -16,4 +16,4 @@
 #
 # Copyright 2023 The Kepler Contributors
 #
-./kind/common.sh
+./kind/common.sh $@


### PR DESCRIPTION
Current Kepler Makefile has `cluster-up`/`cluster-clean`/`cluster-sync`/`cluster-deploy` make targets to manipulate local kind clusters, but lack of cluster destroy operation.
While in local-dev-cluster repo's kind/common.sh, already defined `down()` function, which could implement the kind cluster delete feature.

In current proposed [Platform Validation enhancement](https://github.com/sustainable-computing-io/kepler/pull/711), the test script should support basic setup(kind create cluster) and cleanup(kind delete cluster) ops.

So I am raising this PR along with the above PR to support `make cluster-down` option in Kepler. 