### PR TITLE
Fix the support to load images to local registry

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -21,9 +21,6 @@ set -ex
 set -o pipefail
 
 _registry_port="5001"
-_registry_name="registry"
-DEFAULT_NETWORK="cluster"
-REGISTRY_NAME=${REGISTRY_NAME:-registry}
 REGISTRY_PORT=${REGISTRY_PORT:-5001}
 
 CTR_CMD=${CTR_CMD-docker}
@@ -76,7 +73,7 @@ function main() {
         *)
             _kind_up
             _wait_for_clusterReady
-            _run_registry
+            _run_kind_registry
             ;;
         esac
         echo "cluster is ready"
@@ -98,7 +95,7 @@ function main() {
         echo "by default set up kind cluster"
         _kind_up
         _wait_for_clusterReady
-        _run_registry
+        _run_kind_registry
         echo "cluster is ready"
         ;;
     esac
@@ -112,32 +109,6 @@ function _wait_for_clusterReady() {
         sleep 10
     done
     _wait_containers_ready kube-system
-}
-
-function _run_registry() {
-    until [ -z "$($CTR_CMD ps -a | grep "${REGISTRY_NAME}")" ]; do
-        $CTR_CMD stop "${REGISTRY_NAME}" || true
-        $CTR_CMD rm "${REGISTRY_NAME}" || true
-        sleep 5
-    done
-
-    if [ "${CLUSTER_PROVIDER}" == "kind" ]; then
-        $CTR_CMD run \
-            -d --restart=always \
-            -p "127.0.0.1:${REGISTRY_PORT}:5000" \
-            --name "${REGISTRY_NAME}" \
-            registry:2
-        # connect the registry to the cluster network if not already connected
-        $CTR_CMD network connect "${DEFAULT_NETWORK}" "${REGISTRY_NAME}" || true
-        kubectl apply -f "${KIND_DIR}"/local-registry.yml
-    else
-        $CTR_CMD run \
-            -d --restart=always \
-            -p "127.0.0.1:${REGISTRY_PORT}:5000" \
-            --network "${DEFAULT_NETWORK}" \
-            --name "${REGISTRY_NAME}" \
-            registry:2
-    fi
 }
 
 main "$@"


### PR DESCRIPTION
This PR:
1. Fixes the [bug](https://github.com/sustainable-computing-io/local-dev-cluster/pull/20#issuecomment-1607282697) which got introduced when [PR](https://github.com/sustainable-computing-io/local-dev-cluster/pull/21) got merged.
2. Fixes the support to add prometheus operator images to the local registry and make sure that the cluster pulls the images from the registry. 
3. Refine the `verify.sh` script

CC: @SamYuan1990 @marceloamaral @rootfs 