### PR TITLE
Fix issue #26: Cleanup and simplify code logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,12 @@ jobs:
         # I suppose we'd better update version pre kepler release.
         # keep from current default version and latest version.
         cluster_provider: [kind, microshift]
-        kubectl_version: [v1.27.2]
         # So far we just have a single version for microshift
         # in the future, we should considering have a local test for each cluster providers
-        kind_version: [0.19.0]
     steps:
     - uses: actions/checkout@v3
-    - name: kubectl
-      run: curl -LO https://dl.k8s.io/release/${{matrix.kubectl_version}}/bin/linux/amd64/kubectl
     - name: start from local
       run: | 
-        export KIND_VERSION=${{matrix.kind_version}}
         export CLUSTER_PROVIDER=${{matrix.cluster_provider}}
         ./main.sh up
     - name: verify
@@ -62,8 +57,6 @@ jobs:
         prometheus_operator_version: [v0.12.0]
     steps:
     - uses: actions/checkout@v3
-    - name: kubectl
-      run: curl -LO https://dl.k8s.io/release/v1.25.4/bin/linux/amd64/kubectl
     - name: start from local
       run: | 
         export PROMETHEUS_ENABLE=true

--- a/README.md
+++ b/README.md
@@ -7,13 +7,23 @@ This repo provides the scripts to create a local [kubernetes](kind/kind.sh)/[ope
 
 ## Prerequisites
 - Locate your BCC lib and linux header.
-- [`kubectl`](https://dl.k8s.io/release/v1.25.4)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries)
 
+Please install the same version of `kubectl` and `kind` as Github-hosted runner.
+
+Currently Kepler project's Github Action only supports `Ubuntu` based runners.
+
+You can refer to tools list [here](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools)
 ## Startup
 1. Modify kind [config](./kind/manifests/kind.yml) to make sure `extraMounts:` cover the linux header and BCC.
 2. Export `CLUSTER_PROVIDER` env variable:
 ```
-export CLUSTER_PROVIDER=kind/microshift
+export CLUSTER_PROVIDER=kind
+
+or
+
+export CLUSTER_PROVIDER=microshift
 ```
 3. To setup local env run:
 ```

--- a/lib/prometheus.sh
+++ b/lib/prometheus.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2022 The Kepler Contributors
+# Copyright 2023 The Kepler Contributors
 #
 
 # configuration

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -18,15 +18,15 @@
 #
 
 err() {
-	echo -e "ERROR: $*" >&2
+	echo -e "ERROR: $*\n" >&2
 }
 
 info() {
-	echo -e "INFO : $*" >&2
+	echo -e "INFO : $*\n" >&2
 }
 
 die() {
-	echo -e "FATAL: $*" >&2
+	echo -e "FATAL: $*\n" >&2
 	exit 1
 }
 
@@ -39,11 +39,11 @@ run() {
 }
 
 ok() {
-	echo -e "    ✅ $*" >&2
+	echo -e "    ✅ $*\n" >&2
 }
 
 fail() {
-	echo -e "    ❌ $*" >&2
+	echo -e "    ❌ $*\n" >&2
 }
 
 # returns 0 if arg is set to True or true or TRUE else false

--- a/providers/microshift/microshift.sh
+++ b/providers/microshift/microshift.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2022 The Kepler Contributors
+# Copyright 2023 The Kepler Contributors
 #
 
 set -eu -o pipefail


### PR DESCRIPTION
See #26 

Major change:
1. For `kubectl` and `kind`, using Github-hosted runners' provisioned version.
2. Simplify code logic, remove some unnecessary ENV options.
3. Update README.md and GHA workflow test.yml accordingly.

After this PR be merged, will cleanup related code in kepler-action repo accordingly.

Signed-off-by: Jie Ren <jie.ren@intel.com>