### PR TITLE
Fix infinite wait for nodes

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -57,7 +57,7 @@ wait_for_pods_in_namespace() {
 	shift
 	local timeout="${1:-15m}"
 
-	info "Waiting for all pods in $namespace to be Ready (max $timeout) ..."
+	info "Waiting for all pods in $namespace to be ready (max $timeout) ..."
 	kubectl wait --for=condition=Ready pod --all -n "$namespace" --timeout="$timeout" || {
 		kubectl get pods --field-selector status.phase!=Running -n "$namespace"
 		fail "pods above in $namespace failed to run"
@@ -65,6 +65,20 @@ wait_for_pods_in_namespace() {
 	}
 
 	ok "All pods in $namespace are running"
+	return 0
+}
+
+# shellcheck disable=SC2120
+wait_for_nodes() {
+	local timeout="${1:-15m}"
+
+	info "Waiting for cluster nodes to be ready (max $timeout) ..."
+
+	kubectl wait --for=condition=Ready "$(kubectl get nodes -o name)" --timeout="$timeout" || {
+		fail "node is not in ready state"
+		return 1
+	}
+	ok "all nodes in cluster are running"
 	return 0
 }
 
@@ -86,7 +100,7 @@ wait_for_all_pods() {
 }
 
 wait_for_cluster_ready() {
-	local timeout="${1:-15m}"
+	wait_for_nodes
 
 	info "Waiting for cluster to be ready"
 	kubectl cluster-info

--- a/providers/kind/kind.sh
+++ b/providers/kind/kind.sh
@@ -50,14 +50,6 @@ kind_nodes_ready() {
 }
 
 kind_wait_up() {
-	info "Waiting for kind to be ready ..."
-
-	until kind_nodes_ready; do
-		echo "    ... waiting for all nodes to be ready"
-		sleep 10
-	done
-	ok "all nodes are up and running"
-
 	info "Waiting for dns to be ready ..."
 	kubectl wait -n kube-system --timeout=12m --for=condition=Ready -l k8s-app=kube-dns pods || {
 		fail "dns pods failed to run"
@@ -92,7 +84,6 @@ _setup_kind() {
 	# NOTE: all providers are expected to
 	ok "copied kubeconfig to $KIND_KUBECONFIG"
 
-	kind_wait_up
 }
 
 _run_kind_registry() {
@@ -130,6 +121,7 @@ kind_up() {
 	_prepare_config
 	_setup_kind
 	wait_for_cluster_ready
+	kind_wait_up
 	_run_kind_registry
 	ok "kind cluster $KIND_CLUSTER_NAME is up and running"
 }

--- a/providers/microshift/microshift.sh
+++ b/providers/microshift/microshift.sh
@@ -51,13 +51,6 @@ function _wait_microshift_up {
 		sleep 5
 	done
 	ok "Container $MICROSHIFT_CONTAINER_NAME is now running!\n"
-
-	info "Waiting for cluster nodes to be ready"
-	until microshift_nodes_ready; do
-		echo "    ... waiting for nodes to be ready"
-		sleep 20
-	done
-	ok "all nodes in microshift cluster are running"
 }
 
 function _deploy_microshift_cluster {
@@ -93,6 +86,9 @@ function _setup_microshift() {
 	ok "copied kubeconfig to $MICROSHIFT_KUBECONFIG"
 
 	export KUBECONFIG="$MICROSHIFT_KUBECONFIG"
+
+	info "Sleeping for 60s"
+	sleep 60
 	wait_for_cluster_ready
 }
 


### PR DESCRIPTION
This PR fixes the infinite wait for cluster nodes to be alive. The [issue](https://github.com/sustainable-computing-io/kepler/issues/839) was observed in one of the [CI](https://github.com/sustainable-computing-io/kepler/actions/runs/5682224521/job/15400482462?pr=838) runs.