### PR TITLE
fix: Wait for resources to reach a condition properly

### DIFF
--- a/providers/microshift/microshift.sh
+++ b/providers/microshift/microshift.sh
@@ -87,8 +87,6 @@ function _setup_microshift() {
 
 	export KUBECONFIG="$MICROSHIFT_KUBECONFIG"
 
-	info "Sleeping for 60s"
-	sleep 60
 	wait_for_cluster_ready
 }
 


### PR DESCRIPTION
This removes the need for random sleeps in provider bootup and relies on
resources like `crd`, `nodes`, `pods` to reach the required condition
within a timeout.

Fixes: https://github.com/sustainable-computing-io/local-dev-cluster/issues/46

Signed-off-by: Sunil Thaha <sthaha@redhat.com>