### PR TITLE
fix: update kind preinstall check

### DIFF
--- a/providers/kind/kind.sh
+++ b/providers/kind/kind.sh
@@ -36,7 +36,7 @@ declare -r KIND_REGISTRY_YAML="$KIND_DIR/local-registry.yml"
 declare -r KIND_KUBECONFIG="$KIND_DIR/kubeconfig"
 
 kind_preinstall_check() {
-	command -v kind || command -v kubectl || {
+	(command -v kind && command -v kubectl) || {
 		info "See details here: https://github.com/sustainable-computing-io/local-dev-cluster/blob/main/README.md#prerequisites"
 		die "Please make sure kind and kubectl have been installed before test"
 	}


### PR DESCRIPTION
This PR fixes the check for kind and kubectl before running the step to create a kind cluster. It is in relation to this [issue](https://github.com/sustainable-computing-io/kepler-operator/issues/259)