### PR TITLE
Rapl

### DIFF
--- a/providers/kind/manifests/kind.yml
+++ b/providers/kind/manifests/kind.yml
@@ -15,5 +15,9 @@ nodes:
         containerPath: /proc-host
       - hostPath: /usr/src
         containerPath: /usr/src
+      - hostPath: /sys/class
+        containerPath: /sys/class
+      - hostPath: /sys/devices/virtual/powercap
+        containerPath: /sys/class/powercap
 
 # NOTE: worker nodes will be added by the script here

--- a/providers/kind/update_rapl_permissions.sh
+++ b/providers/kind/update_rapl_permissions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Base directory
+BASE_DIR="/sys/devices/virtual/powercap/intel-rapl"
+
+# Find all 'energy_uj' files in directories starting with 'intel-rapl' and change their permissions
+find $BASE_DIR -type f -name 'energy_uj' -path "$BASE_DIR/intel-rapl*" -exec sudo chmod a+r {} \;
+
+echo "Permissions updated for all 'energy_uj' files in directories starting with 'intel-rapl*' under $BASE_DIR"
+


### PR DESCRIPTION
@SamYuan1990 @vprashar2929 Added the following to enable the usage of RAPL metrics in Kind Cluster:

- script to change read permissions of RAPL files on host 
- mount powercap directory into cluster  

Maybe should also be adjusted in "kind.sh"? 