### PR TITLE
Merge multiple kubeconfig files into one

### DIFF
--- a/providers/kind/kind.sh
+++ b/providers/kind/kind.sh
@@ -90,7 +90,7 @@ _setup_kind() {
 	run kind create cluster --name="${KIND_CLUSTER_NAME}" -v6 --config="$KIND_CONFIG_YAML"
 
 	info "Generating kubeconfig"
-	kind get kubeconfig --name="${KIND_CLUSTER_NAME}" >"$KIND_KUBECONFIG"
+	kind get kubeconfig --name="${KIND_CLUSTER_NAME}" | sed 's/kind-kind/kind-kepler/' > "$KIND_KUBECONFIG"
 
 	# NOTE: all providers are expected to
 	ok "copied kubeconfig to $KIND_KUBECONFIG"


### PR DESCRIPTION
Issue #52 shows a bug that the Kepler cluster up overwrite the configuration of other clusters.

This PR merge multiple kubeconfig files into one, so that the user can use multiple clusters.

Note that, the kubeconfig files must have the `config` substring.