### PR TITLE
add container level test and refine document

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,3 +86,33 @@ jobs:
       run: |
         export CLUSTER_PROVIDER=${{matrix.cluster_provider}}
         ./verify.sh
+
+  containertestubuntu:
+    needs:
+      - shellcheck
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - OS: ubuntu
+        - OS: ubi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: test image with container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./test/${{matrix.OS}}.Dockerfile
+          platforms: linux/amd64
+          #,linux/arm64,linux/s390x later
+          push: false
+          tags: testcontainer:latest
+

--- a/README.md
+++ b/README.md
@@ -5,15 +5,29 @@
 
 This repo provides the scripts to create a local [kubernetes](kind/kind.sh)/[openshift](microshift/microshift.sh) cluster to be used for development or integration tests. It is also used in [Github action](https://github.com/sustainable-computing-io/kepler-action) for kepler.
 
-## Prerequisites
+## Prerequisites for this REPO
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries)
+- [Git](https://git-scm.com/)
 
 Please install the same version of `kubectl` and `kind` as Github-hosted runner.
 
 Currently Kepler project's Github Action only supports `Ubuntu` based runners.
 
 You can refer to tools list [here](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools)
+
+## Prerequisites (optional)
+```
+./main.sh prerequisites
+```
+Will setup ebpf on your host instance.
+
+## Container runtime (optional)
+```
+./main.sh containerruntime
+```
+Will setup container runtime on your host instance.
+
 ## Startup
 1. Modify kind [config](./kind/manifests/kind.yml) to make sure `extraMounts:` cover the linux header and BCC.
 2. Export `CLUSTER_PROVIDER` env variable:

--- a/test/ubi.Dockerfile
+++ b/test/ubi.Dockerfile
@@ -1,0 +1,13 @@
+From registry.access.redhat.com/ubi9
+
+USER 0
+
+WORKDIR /workspace
+
+COPY . .
+RUN yum update -y && yum install -y git sudo
+#RUN yum install -y yum-utils
+#RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+#RUN yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+RUN sudo ./main.sh containerruntime
+RUN sudo ./verify.sh containerruntime

--- a/test/ubuntu.Dockerfile
+++ b/test/ubuntu.Dockerfile
@@ -1,0 +1,8 @@
+From ubuntu
+
+WORKDIR /workspace
+
+COPY . .
+RUN apt-get update -y && apt-get install -y git sudo
+RUN ./main.sh containerruntime
+RUN ./verify.sh containerruntime

--- a/verify.sh
+++ b/verify.sh
@@ -61,6 +61,12 @@ verify_cluster() {
 	ok "Cluster is up and running"
 }
 
+containerruntime() {
+	which docker
+	# there is a docker in docker issue on GHA, use a or true logic as workaround
+	docker info || true
+}
+
 main() {
 	# verify the deployment of cluster
 	case $1 in
@@ -69,6 +75,9 @@ main() {
 		;;
 	cluster)
 		verify_cluster
+		;;
+	containerruntime)
+		containerruntime
 		;;
 	all | *)
 		verify_bcc


### PR DESCRIPTION
add container test for container runtime install, as GHA locks down gnupg keys and container runtime for ubi. 