### PR TITLE
enable ubi support

### DIFF
--- a/test/ubi.Dockerfile
+++ b/test/ubi.Dockerfile
@@ -9,5 +9,6 @@ RUN yum update -y && yum install -y git sudo
 #RUN yum install -y yum-utils
 #RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 #RUN yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+RUN sudo ./main.sh prerequisites
 RUN sudo ./main.sh containerruntime
 RUN sudo ./verify.sh containerruntime


### PR DESCRIPTION
maybe this PR can't been tested with GHA, as GHA customer it's linux header?

should we install kernel-devel and other packages for linux header and other header related pacakges? @rootfs 