### PR TITLE
Remove whole $KUBECONFIG_ROOT_DIR when cleanup

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -98,7 +98,7 @@ cluster_up() {
 
 cluster_down() {
 	"$CLUSTER_PROVIDER"_down
-	rm "$KUBECONFIG_ROOT_DIR/$KEPLER_KUBECONFIG"
+	rm -r "$KUBECONFIG_ROOT_DIR"
 }
 
 print_config() {


### PR DESCRIPTION
Instead of only removing config-kepler file, remove the whole .kube dir created by cluster_up().