### PR TITLE
Doc update jul24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ kube-prometheus/
 .vscode/
 .idea/
 *.iml
+bin/
+lib/python3.12
+pyvenv.cfg
 
 # Logs
 logs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,15 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/markdownlint/markdownlint.git
-  rev: v0.13.0
-  hooks:
-  - id: markdownlint_docker
-  name: Markdownlint Docker
-  description: Run markdown lint on your Markdown files using the project docker image
-  language: docker_image
-  files: \.(md|mdown|markdown)$
-  entry: markdownlint/markdownlint
+#- repo: https://github.com/markdownlint/markdownlint.git
+#  rev: v0.13.0
+#  hooks:
+  #- id: markdownlint_docker
+  #name: Markdownlint Docker
+  #description: Run markdown lint on your Markdown files using the project docker image
+  #language: docker_image
+  #files: \.(md|mdown|markdown)$
+  #entry: markdownlint/markdownlint
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.10.0.1
   hooks:

--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ Will setup container runtime on your host instance.
 
 ## Startup
 
+**note**: in 2024 July, we decoupled cluster config with kind cluster setup, so that we allow this repo to set up a existing cluster.
+
 1. Modify kind [config](./kind/manifests/kind.yml) to make sure `extraMounts:` cover
    the linux header and BCC.
 2. To setup local env run:
 
     ```bash
     ./main.sh up
+    ./main.sh config
     ```
 
 3. To tear down local env run:
@@ -67,6 +70,7 @@ Will setup container runtime on your host instance.
 
     ```sh
     ./main.sh up
+    ./main.sh config
     ```
 
 ## Container registry


### PR DESCRIPTION
update on git ignore file to avoid local venv settings
update document and disable markdown hook as image pull fail
```
Unable to find image 'markdownlint/markdownlint:latest' locally
latest: Pulling from markdownlint/markdownlint
213ec9aee27d: Already exists 
5bedfe54446b: Retrying in 1 second 
docker: error pulling image configuration: download failed after attempts=6: context deadline exceeded.
```